### PR TITLE
Fix EZP-25181: The richtext toolbar don't close when we change field focus

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "ez-js-rest-client": "ezsystems/ez-js-rest-client",
     "yui3": "http://yui.zenfs.com/releases/yui3/yui_3.18.1.zip",
     "flag-icon-css": "~0.6.4",
-    "alloy-editor": "liferay/alloy-editor#~0.6.0",
+    "alloy-editor": "ezsystems/alloy-editor#~0.6.0",
     "widget": "http://download.ckeditor.com/widget/releases/widget_4.5.3.zip",
     "lineutils": "http://download.ckeditor.com/lineutils/releases/lineutils_4.5.3.zip"
   }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25181

# Description

This is actually an AlloyEditor bug reported in https://github.com/liferay/alloy-editor/issues/371. It's fixed in AlloyEditor 0.7.0 but we can not really upgrade right now, so we temporarily use our own AlloyEditor fork to get a 0.6 version with the fix for this issue.

# Tests

manual tests