### PR TITLE
Add React.js depedency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "flag-icon-css": "~0.6.4",
     "alloy-editor": "liferay/alloy-editor#~0.7.5",
     "widget": "http://download.ckeditor.com/widget/releases/widget_4.5.5.zip",
-    "lineutils": "http://download.ckeditor.com/lineutils/releases/lineutils_4.5.5.zip"
+    "lineutils": "http://download.ckeditor.com/lineutils/releases/lineutils_4.5.5.zip",
+    "react": "0.14.2"
   }
 }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25625

Added a dependency to React.js v. 0.14.2 - the same as the one used with current version of Alloy Editor.
