### PR TITLE
EZP-25713: Reduce size of asset bundle further

### DIFF
--- a/bin/prepare_release.sh
+++ b/bin/prepare_release.sh
@@ -43,6 +43,8 @@ check_command "bower"
 VENDOR_DIR=`cat .bowerrc | grep "directory" | cut -d ':' -f 2 | sed 's/[ "]//g'`
 YUI3_DIR="$VENDOR_DIR/yui3"
 YUI3_NOTICE="$YUI3_DIR/YUI3_IN_PLATFORMUIASSETSBUNDLE.txt"
+ALLOY_DIR="$VENDOR_DIR/alloy-editor"
+ALLOY_NOTICE="$ALLOY_DIR/ALLOY_IN_PLATFORMUIASSETSBUNDLE.txt"
 
 CURRENT_BRANCH=`git branch | grep '*' | cut -d ' ' -f 2`
 TMP_BRANCH="version_$VERSION"
@@ -62,11 +64,18 @@ bower install
 check_process "run bower"
 
 echo "# Removing, docs, API docs and tests from YUI"
-rm -rf "$YUI3_DIR/api" "$YUI3_DIR/docs" "$YUI3_DIR/tests"
+rm -rf "$YUI3_DIR/api" "$YUI3_DIR/docs" "$YUI3_DIR/tests" "$YUI3_DIR/build/*/*-coverage.js" "$YUI3_DIR/build/*/*-debug.js"
 check_process "clean YUI"
 echo "This is a customized YUI3 version." > $YUI3_NOTICE
 echo "To decrease the size of the bundle, it does not include the API docs," >> $YUI3_NOTICE
-echo "the documentation and the unit tests" >> $YUI3_NOTICE
+echo "the documentation, the unit tests or the generated debug/coverage versions of YUI code." >> $YUI3_NOTICE
+
+echo "# Removing API docs and lib from alloy-editor"
+rm -rf "$ALLOY_DIR/api" "$ALLOY_DIR/lib"
+check_process "clean alloy-editor"
+echo "This is a customized Alloy version." > $ALLOY_NOTICE
+echo "To decrease the size of the bundle, it does not include API docs and lib" >> $ALLOY_NOTICE
+
 
 echo "# Creating the custom branch: $TMP_BRANCH"
 git checkout -q -b "$TMP_BRANCH" > /dev/null


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25713

YUI:
- $YUI3_DIR/build/\*/\*-debug.js
- $YUI3_DIR/build/\*/\*-coverage.js

Build folder total is 36,7mb, and these files are the biggest once.
![_yui](https://cloud.githubusercontent.com/assets/289757/14707487/591cc0a6-07c5-11e6-8cff-a4a7e06f86ea.png)

Alloy:
- $ALLOY_DIR/api
- $ALLOY_DIR/lib

This assumes `dist/` folder is all we need in prod.
![_alloy_all](https://cloud.githubusercontent.com/assets/289757/14707495/63097f14-07c5-11e6-8988-7b170cf5b4e7.png)

For future tuning we can look into if parts of `dist/` folder can be removed as well, ref: 

![_alloy](https://cloud.githubusercontent.com/assets/289757/14707504/7065b4b6-07c5-11e6-9acf-75e0e1bee4ac.png)
