### PR TITLE
Allow Symfony 3 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": "~2.5"
+        "symfony/symfony": "^2.5 | ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Right now, eZ Platform 1.5 cannot be tested with Symfony 3 due to this, even when eZ kernel itself allows it.