### PR TITLE
Handlebars intl

### DIFF
--- a/bin/prepare_release.sh
+++ b/bin/prepare_release.sh
@@ -58,7 +58,7 @@ check_process "switch to master"
 
 echo "# Removing the assets"
 [ ! -d "$VENDOR_DIR" ] && mkdir -p $VENDOR_DIR
-[ -d "$VENDOR_DIR" ] && rm -rf "$VENDOR_DIR/*"
+[ -d "$VENDOR_DIR" ] && rm -rf $VENDOR_DIR/*
 check_process "clean the vendor dir $VENDOR_DIR"
 
 echo "# Bower install"
@@ -66,7 +66,7 @@ bower install
 check_process "run bower"
 
 echo "# Removing, docs, API docs and tests from YUI"
-rm -rf "$YUI3_DIR/api" "$YUI3_DIR/docs" "$YUI3_DIR/tests" "$YUI3_DIR/build/*/*-coverage.js" "$YUI3_DIR/build/*/*-debug.js"
+rm -rf "$YUI3_DIR/api" "$YUI3_DIR/docs" "$YUI3_DIR/tests" $YUI3_DIR/build/*/*-coverage.js $YUI3_DIR/build/*/*-debug.js
 check_process "clean YUI"
 echo "This is a customized YUI3 version." > $YUI3_NOTICE
 echo "To decrease the size of the bundle, it does not include the API docs," >> $YUI3_NOTICE

--- a/bin/prepare_release.sh
+++ b/bin/prepare_release.sh
@@ -45,6 +45,8 @@ YUI3_DIR="$VENDOR_DIR/yui3"
 YUI3_NOTICE="$YUI3_DIR/YUI3_IN_PLATFORMUIASSETSBUNDLE.txt"
 ALLOY_DIR="$VENDOR_DIR/alloy-editor"
 ALLOY_NOTICE="$ALLOY_DIR/ALLOY_IN_PLATFORMUIASSETSBUNDLE.txt"
+INTL_DIR="$VENDOR_DIR/handlebars-helper-intl"
+INTL_NOTICE="$INTL_DIR/INTL_IN_PLATFORMUIASSETSBUNDLE.txt"
 
 CURRENT_BRANCH=`git branch | grep '*' | cut -d ' ' -f 2`
 TMP_BRANCH="version_$VERSION"
@@ -76,6 +78,11 @@ check_process "clean alloy-editor"
 echo "This is a customized Alloy version." > $ALLOY_NOTICE
 echo "To decrease the size of the bundle, it does not include API docs and lib" >> $ALLOY_NOTICE
 
+echo "# Removing js maps from handlebars-helper-intl"
+rm -rf $INTL_DIR/dist/*.map
+check_process "clean handlebars-helper-intl"
+echo "This is a customized handlebars-helper-intl version." > $INTL_NOTICE
+echo "To decrease the size of the bundle, it does not include js maps" >> $INTL_NOTICE
 
 echo "# Creating the custom branch: $TMP_BRANCH"
 git checkout -q -b "$TMP_BRANCH" > /dev/null

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "flag-icon-css": "~0.6.4",
     "alloy-editor": "liferay/alloy-editor#~1.2.3",
     "widget": "http://download.ckeditor.com/widget/releases/widget_4.5.9.zip",
-    "lineutils": "http://download.ckeditor.com/lineutils/releases/lineutils_4.5.9.zip"
+    "lineutils": "http://download.ckeditor.com/lineutils/releases/lineutils_4.5.9.zip",
+    "handlebars-helper-intl": "~1.1.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "eZ Platform UI Assets",
-  "version": "3.0.2",
+  "name": "ez-platform-ui-assets-bundle",
+  "version": "3.1.0",
   "homepage": "https://github.com/ezsystems/PlatformUIAssetsBundle",
   "authors": [
     "eZ Systems"

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "pure": "~0.6",
-    "ez-js-rest-client": "ezsystems/ez-js-rest-client#^1.3.0",
+    "ez-js-rest-client": "ezsystems/ez-js-rest-client#^1.4.0",
     "yui3": "http://yui.zenfs.com/releases/yui3/yui_3.18.1.zip",
     "flag-icon-css": "~0.6.4",
     "alloy-editor": "liferay/alloy-editor#~1.2.3",


### PR DESCRIPTION
As needed by https://github.com/ezsystems/PlatformUIBundle/pull/767

Besides addition of handlebars-helper-intl:
- Bump version of rest client to 1.4.0 _(currently in beta)_
- Update bower name to be lowercase to avoid warning from bower
- Fix YUI trimming on release "Don't use quote on paths with matchers, doesn't work on Mac/?"

Test tag: `v3.1.0-alpha1` size 11.3mb, *down from 15.9mb on `v3.0.2`. In `v3.1.0-alpha1` added handlebars-helper-intl files accounts for 1.4mb uncompressed, so the reduction is thanks to ed1f856.*