### PR TITLE
EZP-27650: + button is not visible in RichText

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "alloy-editor": "liferay/alloy-editor#~1.2.3",
     "widget": "http://download.ckeditor.com/widget/releases/widget_4.5.9.zip",
     "lineutils": "http://download.ckeditor.com/lineutils/releases/lineutils_4.5.9.zip",
-    "handlebars-helper-intl": "~1.1.2"
+    "handlebars-helper-intl": "~1.1.2",
+    "react": "0.14.2"
   }
 }


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-27650

**Requires:**
https://github.com/ezsystems/PlatformUIBundle/pull/906

**Description:**
This version of React is used by AlloyEditor.